### PR TITLE
New way of inline translations without breaking layouts

### DIFF
--- a/config/laravel-translation-manager.php
+++ b/config/laravel-translation-manager.php
@@ -50,6 +50,12 @@ return array(
      */
     'admin_enabled' => true,
     /**
+     *  Inplace edit mode
+     *  1 - Using trans(), noEditTrans(), ifEditTrans() in all templates
+     *  2 - Only by modifying application template (disables ifEditTrans and reverts trans() to default functionality)
+     */
+    'inplace_edit_mode' => 2,
+    /**
      * Enable management of translations for editors by locales
      *
      * Only applies to users that are not translation admins

--- a/public/css/translations.css
+++ b/public/css/translations.css
@@ -1,3 +1,14 @@
+.transpopup {
+    overflow: auto;
+    max-width: 95%;
+    max-height: 95%;
+    display:flex;
+    padding-right: 20px;
+    flex-direction:column;
+    background-color: #f7f7f7;
+    border: 1px solid #c2e1f5 !important;
+}
+
 .editable-click,
 a.editable-click,
 a.editable-click:hover {

--- a/public/js/translations.js
+++ b/public/js/translations.js
@@ -268,19 +268,19 @@ $(document).ready(function () {
         '</form>';
 
     $.fn.editableform.buttons = '' +
-        '<button type="submit" id="x-submit" class="editable-submit btn btn-sm btn-success"><i class="glyphicon glyphicon-ok"></i></button>' +
-        '&nbsp;<button type="button" id="x-cancel" class="editable-cancel btn btn-sm btn-danger"><i class="glyphicon glyphicon-remove"></i></button>' +
-        '&nbsp;&nbsp;<button id="x-translate" type="button" class="editable-translate btn btn-sm btn-warning hidden"><i class="glyphicon glyphicon-share-alt"></i></button>' +
-        '<button id="x-nodash" type="button" class="editable-translate btn btn-sm btn-warning hidden">❉ <i class="glyphicon glyphicon-share-alt"></i> Ab</button>' +
-        '&nbsp;&nbsp;<button id="x-plurals" type="button" class="editable-translate btn btn-sm btn-warning hidden">|</i></button>' +
-        '<button id="x-clean-markdown" type="button" class="editable-translate btn btn-sm btn-warning hidden"><i class="glyphicon glyphicon-flash"></i></button>' +
-        '&nbsp;&nbsp;<button id="x-capitalize" type="button" class="editable-translate btn btn-sm btn-info">ab <i class="glyphicon glyphicon-share-alt"></i> Ab</button>' +
-        '<button id="x-lowercase" type="button" class="editable-translate btn btn-sm btn-info">AB <i class="glyphicon glyphicon-share-alt"></i> ab</button>' +
-        '<button id="x-propcap" type="button" class="editable-translate btn btn-sm btn-info">A B <i class="glyphicon glyphicon-share-alt"></i> A b</button>' +
-        '&nbsp;&nbsp;<button id="x-copy" type="button" class="editable-translate btn btn-sm btn-primary"><i class="glyphicon glyphicon-copy"></i></button>' +
-        '<button id="x-paste" type="button" class="editable-translate btn btn-sm btn-primary"><i class="glyphicon glyphicon-paste"></i></button>' +
-        '&nbsp;&nbsp;<button id="x-reset-open" type="button" class="editable-translate btn btn-sm btn-success"><i class="glyphicon glyphicon-open"></i></button>' +
-        '<button id="x-reset-saved" type="button" class="editable-translate btn btn-sm btn-success"><i class="glyphicon glyphicon-floppy-open"></i></button>' +
+        '<button type="submit" title="Save changes" id="x-submit" class="editable-submit btn btn-sm btn-success"><i class="glyphicon glyphicon-ok"></i></button>' +
+        '&nbsp;<button type="button" title="Cancel changes" id="x-cancel" class="editable-cancel btn btn-sm btn-danger"><i class="glyphicon glyphicon-remove"></i></button>' +
+        '&nbsp;&nbsp;<button id="x-translate" type="button" title="Translate" class="editable-translate btn btn-sm btn-warning hidden"><i class="glyphicon glyphicon-share-alt"></i></button>' +
+        '<button id="x-nodash" type="button" title="Convert translation key to text" class="editable-translate btn btn-sm btn-warning hidden">❉ <i class="glyphicon glyphicon-share-alt"></i> Ab</button>' +
+        '&nbsp;&nbsp;<button id="x-plurals" type="button" title="Generate plural forms" class="editable-translate btn btn-sm btn-warning hidden">|</i></button>' +
+        '<button id="x-clean-markdown" type="button" title="Clean HTML markdown" class="editable-translate btn btn-sm btn-warning hidden"><i class="glyphicon glyphicon-flash"></i></button>' +
+        '&nbsp;&nbsp;<button id="x-capitalize" type="button" title="Uppercase the first character of each word in the string" class="editable-translate btn btn-sm btn-info">ab <i class="glyphicon glyphicon-share-alt"></i> Ab</button>' +
+        '<button id="x-lowercase" type="button" title="Make the string lowercase" class="editable-translate btn btn-sm btn-info">AB <i class="glyphicon glyphicon-share-alt"></i> ab</button>' +
+        '<button id="x-propcap" type="button" title="Make the string\'s first character uppercase" class="editable-translate btn btn-sm btn-info">A B <i class="glyphicon glyphicon-share-alt"></i> A b</button>' +
+        '&nbsp;&nbsp;<button id="x-copy" type="button" title="Copy text to simulated clipboard (page refresh clears contents)" class="editable-translate btn btn-sm btn-primary"><i class="glyphicon glyphicon-copy"></i></button>' +
+        '<button id="x-paste" type="button" title="Paste text from simulated clipboard" class="editable-translate btn btn-sm btn-primary"><i class="glyphicon glyphicon-paste"></i></button>' +
+        '&nbsp;&nbsp;<button id="x-reset-open" type="button" title="Reset editor contents" class="editable-translate btn btn-sm btn-success"><i class="glyphicon glyphicon-open"></i></button>' +
+        '<button id="x-reset-saved" type="button" title="Load last published/imported value" class="editable-translate btn btn-sm btn-success"><i class="glyphicon glyphicon-floppy-open"></i></button>' +
         '<br>&nbsp;';
 
     function textAreaSelectedText(elemTextArea) {

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -14,6 +14,8 @@
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap-theme.min.css">
     <link href="//cdnjs.cloudflare.com/ajax/libs/x-editable/1.5.0/bootstrap3-editable/css/bootstrap-editable.css" rel="stylesheet"/>
     <link href="<?= $public_prefix ?>laravel-translation-manager/css/translations.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.4.0/css/font-awesome.min.css" rel='stylesheet'
+          type='text/css'>
     @yield('head')
     {{--<!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->--}}
     <!--[if lt IE 9]>
@@ -24,13 +26,16 @@
 <body role="document">
 <noscript>This site does not work without JavaScript</noscript>
 
-@if(inPlaceEditing())
+@if(inPlaceEditing() && inPlaceEditingMode()==1)
     <div class="top-spacer" style="min-height: 50px"></div>
 @endif
 
 <div id="main" class="container-fluid main theme-showcase" role="main">
     @yield('content')
 </div>
+
+{!! getEditableLinks() !!}
+
 {{--<!--================================================== -->--}}
 {{--<!-- Placed at the end of the document so the pages load faster -->--}}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>

--- a/src/Support/helpers.php
+++ b/src/Support/helpers.php
@@ -136,12 +136,23 @@ if (!function_exists('ifEditTrans')) {
     function ifEditTrans($key, $parameters = null, $locale = null, $useDB = null, $noWrap = null)
     {
         $trans = App::make('translator');
-        if ($trans->inPlaceEditing()) {
+        if ($trans->inPlaceEditing() && $trans->getInPlaceEditingMode() == 1) {
             /* @var $trans Translator */
             $text = $trans->getInPlaceEditLink($key, $parameters ?: [], $locale, $useDB);
             return $noWrap ? $text : "<br>[$text]";
         }
         return '';
+    }
+}
+
+if (!function_exists('getEditableLinks')) {
+    /**
+     * @return string
+     *
+     */
+    function getEditableLinks() {
+        $trans = App::make('translator');
+        return $trans->getEditableLinks();
     }
 }
 
@@ -159,9 +170,9 @@ if (!function_exists('ifInPlaceEdit')) {
     {
         /* @var $trans Translator */
         $trans = App::make('translator');
-        if ($trans->inPlaceEditing()) {
+        if ($trans->inPlaceEditing() && $trans->getInPlaceEditingMode() == 1 ) {
             while (preg_match('/@lang\(\'([^\']+)\'\)/', $text, $matches)) {
-                $repl = $trans->getInPlaceEditLink($matches[1], $replace, $locale, $noWrap, $useDB);
+                $repl = $trans->getInPlaceEditLink($matches[1], $replace, $locale, $useDB);
                 $text = str_replace($matches[0], $repl, $text);
             }
             return $noWrap ? $text : "<br>[$text]";
@@ -179,6 +190,18 @@ if (!function_exists('inPlaceEditing')) {
     {
         $trans = App::make('translator');
         return $trans->inPlaceEditing($inPlaceEditing);
+    }
+}
+
+if (!function_exists('inPlaceEditingMode')) {
+    /**
+     * @return int
+     *
+     */
+    function inPlaceEditingMode()
+    {
+        $trans = App::make('translator');
+        return $trans->getInPlaceEditingMode();
     }
 }
 


### PR DESCRIPTION
Here is the new way of translations as discussed in (with animations)
https://github.com/vsch/laravel-translation-manager/issues/38
Because the old way is cumbersome and needs modifying the way laravel is doing translations...

In addition, it allows translating ALL text created by trans()/choice() functions when page is loaded/rendered. Not only those found in the view blade templates. For example if you used trans() inside the controller and passed the resulting text as a variable to blade template, you can still translate that specific key even though it was not used in the template itself!

Below are gif animations of how it works as examples:
Tooltips for remembering which button does what :)
![tooltips](https://cloud.githubusercontent.com/assets/1926599/16388352/76e6e560-3ca1-11e6-9703-69e92079499c.gif)
A page with two trans() keys only...
![newinline1](https://cloud.githubusercontent.com/assets/1926599/16388359/7d41da1e-3ca1-11e6-84de-b65fb15d76ad.gif)
The translator page with many keys (compare with how ugly the page looked when old inline translations were enabled).
![newinline2](https://cloud.githubusercontent.com/assets/1926599/16388363/81b84362-3ca1-11e6-9bb1-58fe02bdfff7.gif)
