### PR TITLE
Setting PDO Fetch mode to FETCH_CLASS

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -39,6 +39,7 @@ class Controller extends BaseController
     function getConnection()
     {
         $connection = $this->manager->getConnection();
+		$connection->setFetchMode(\PDO::FETCH_CLASS);
         return $connection;
     }
 


### PR DESCRIPTION
Library would not work with connections with non-default fetch modes (e.g. FETCH_ASSOC), so we set it explicitly.