### PR TITLE
made the translations:find command more flexible

### DIFF
--- a/config/laravel-translation-manager.php
+++ b/config/laravel-translation-manager.php
@@ -397,4 +397,34 @@ return array(
      */
     'zip_root' => '/resources',
 
-);
+    'find' => [
+        'functions' => ($functions = [
+            'trans',
+            'trans_choice',
+            'noEditTrans',
+            'ifEditTrans',
+            'Lang::get',
+            'Lang::choice',
+            'Lang::trans',
+            'Lang::transChoice',
+            '@lang',
+            '@choice',
+            '__',
+        ]),
+        'pattern' => [                              // See http://regexr.com/392hu
+            '(' . implode('|', $functions) . ')',   // Must start with one of the functions
+            '\\(',                                  // Match opening parentheses
+            "(['\"])",                              // Match " or '
+            '(',                                    // Start a new group to match:
+            '[a-zA-Z0-9_-]+',                       // Must start with group
+            "([.][^\1)]+)+",                        // Be followed by one or more items/keys
+            ')',                                    // Close group
+            "['\"]",                                // Closing quote
+            '[\\),]',                                // Close parentheses or new parameter
+        ],
+        'files' => [
+            'php',
+            'twig',
+        ],
+    ],
+];

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -964,36 +964,15 @@ class Manager
 
     public function findTranslations($path = null)
     {
-        $functions = array(
-            'trans',
-            'trans_choice',
-            'noEditTrans',
-            'ifEditTrans',
-            'Lang::get',
-            'Lang::choice',
-            'Lang::trans',
-            'Lang::transChoice',
-            '@lang',
-            '@choice',
-            '__',
-        );
-        $pattern =                                  // See http://regexr.com/392hu
-            "(" . implode('|', $functions) . ")" .  // Must start with one of the functions
-            "\\(" .                                 // Match opening parentheses
-            "(['\"])" .                             // Match " or '
-            "(" .                                   // Start a new group to match:
-            "[a-zA-Z0-9_-]+" .                  // Must start with group
-            "([.][^\1)]+)+" .                   // Be followed by one or more items/keys
-            ")" .                                   // Close group
-            "['\"]" .                               // Closing quote
-            "[\\),]";                               // Close parentheses or new parameter
+        $functions = config('laravel-translation-manager.find.functions');
+        $pattern = implode('', config('laravel-translation-manager.find.pattern'));
 
         // Find all PHP + Twig files in the app folder, except for storage
         $paths = $path ? [$path] : array_merge([$this->app->basePath() . '/app'], $this->app['config']['view']['paths']);
         $keys = array();
         foreach ($paths as $path) {
             $finder = new Finder();
-            $finder->in($path)->name('*.php')->name('*.twig')->files();
+            $finder->in($path)->name("*.{" . implode(',', config('laravel-translation-manager.find.files')) . "}")->files();
 
             /** @var \Symfony\Component\Finder\SplFileInfo $file */
             foreach ($finder as $file) {


### PR DESCRIPTION
abstracting some of the variables used in the translations:find command to the configuration file for added flexibility

This commit lacks documentation of any kind and is only meant as a starting point for how you may improve your package.

It does work the same as before but this way it's now possible to adapt to other use-cases

For example the default is

```
    'find' => [
        'functions' => ( $functions = [
            'trans',
            'trans_choice',
            'noEditTrans',
            'ifEditTrans',
            'Lang::get',
            'Lang::choice',
            'Lang::trans',
            'Lang::transChoice',
            '@lang',
            '@choice',
            '__',
        ]),
        'pattern' => [                              // See http://regexr.com/392hu
            '(' . implode('|', $functions) . ')',   // Must start with one of the functions
            '\\(',                                  // Match opening parentheses
            "(['\"])",                              // Match " or '
            '(',                                    // Start a new group to match:
            '[a-zA-Z0-9_-]+',                       // Must start with group
            "([.][^\1)]+)+",                        // Be followed by one or more items/keys
            ')',                                    // Close group
            "['\"]",                                // Closing quote
            '[\\),]',                               // Close parentheses or new parameter
        ],
        'files' => [
            'php',
            'twig',
        ],
    ],
```

But in my case I can now change it easily to

```
    'find' => [
        'functions' => ( $functions = [
            '\$t',
        ]),
        // no changes in pattern
        'files' => [
            'vue',
            'js',
        ],
    ],
```

Without editing vendor files